### PR TITLE
Add migrator for `build.tools`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,6 @@ doc = [
 
 [tool.isort]
 profile = "black"
+
+[tool.pytest.ini_options]
+asyncio_mode = "strict"

--- a/src/readthedocs_assistant/cli.py
+++ b/src/readthedocs_assistant/cli.py
@@ -82,7 +82,7 @@ async def main(username: str, token: str, owner: str, repository_name: str) -> N
         unvalidated_config = load(
             await load_contents(forked_repo, config_item["path"], gh=gh), Loader=Loader
         )
-        config = await validate_config(unvalidated_config, client=client)
+        config = await validate_config(unvalidated_config)
 
         # At this point, the repository is forked and the configuration is validated
         # and we can do whatever change we want to do

--- a/src/readthedocs_assistant/cli.py
+++ b/src/readthedocs_assistant/cli.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
-import logging
+import logging  # TODO: Migrate to structlog
 import os
 import re
 from typing import TYPE_CHECKING, Any, cast
@@ -113,16 +113,21 @@ async def main(username: str, token: str, owner: str, repository_name: str) -> N
 
         logger.info("New config: %s", new_config)
 
+        # TODO: Create pull request with message
+        # TODO: Add interactive/dry run mode to manually compare changes
+        # before opening pull request
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
 
-    # For testing purposes
+    # TODO: Add cli parameter to pick migrator
+    # TODO: Detect migrations and write small report
     asyncio.run(
         main(
             os.environ["GH_USERNAME"],
             os.environ["GH_TOKEN"],
-            "jupyterlite",
+            "jupyterlite",  # TODO: Do not hardcode repositories
             "jupyterlite",
         )
     )

--- a/src/readthedocs_assistant/migrators.py
+++ b/src/readthedocs_assistant/migrators.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 
-from .types import RTDConfig, V2Build
+from .types import RTDConfig
 
 logger = logging.getLogger(__name__)
 
@@ -29,12 +29,10 @@ async def use_build_tools(config: RTDConfig) -> tuple[RTDConfig, bool]:
     # From 4.0 onwards, the default Python version was 3.7
     python_version = config.get("python", {}).get("version", "3.7")
 
-    new_config["build"] = V2Build(
-        {
-            "os": "ubuntu-20.04",
-            "tools": {"python": python_version},
-        }
-    )
+    new_config["build"] = {
+        "os": "ubuntu-20.04",
+        "tools": {"python": python_version},
+    }
     if apt_packages := new_config.get("build", {}).get("apt_packages", []):
         new_config["build"]["apt_packages"] = apt_packages
 

--- a/src/readthedocs_assistant/migrators.py
+++ b/src/readthedocs_assistant/migrators.py
@@ -20,10 +20,15 @@ async def use_build_tools(
         raise MigrationError("Config uses V1, migrate to V2 first")
 
     if config.get("build", {}).get("tools"):
+        # TODO: Signal that nothing was done to avoid further action!
         logger.info("Config already contains build.tools, nothing to do")
         return config
 
     new_config = config.copy()
+    # FIXME: Python version depends on build.image
+    # For example:
+    # 2.0 -> 3.5
+    # 3.0... -> 3.7
     python_version = config.get("python", {}).get("version", default_python_version)
 
     new_config["build"] = V2Build(

--- a/src/readthedocs_assistant/migrators.py
+++ b/src/readthedocs_assistant/migrators.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 from .types import RTDConfig, V2Build
@@ -9,7 +11,7 @@ class MigrationError(RuntimeError):
     pass
 
 
-async def use_build_tools(config: RTDConfig) -> RTDConfig:
+async def use_build_tools(config: RTDConfig) -> tuple[RTDConfig, bool]:
     """Migrate to build.tools configuration
 
     See https://docs.readthedocs.io/en/latest/config-file/v2.html#build.
@@ -18,9 +20,8 @@ async def use_build_tools(config: RTDConfig) -> RTDConfig:
         raise MigrationError("Config uses V1, migrate to V2 first")
 
     if config.get("build", {}).get("tools"):
-        # TODO: Signal that nothing was done to avoid further action!
         logger.info("Config already contains build.tools, nothing to do")
-        return config
+        return config, False
 
     new_config = config.copy()
 
@@ -44,4 +45,4 @@ async def use_build_tools(config: RTDConfig) -> RTDConfig:
     if "python" in new_config and not new_config["python"]:
         new_config.pop("python")
 
-    return new_config
+    return new_config, True

--- a/src/readthedocs_assistant/migrators.py
+++ b/src/readthedocs_assistant/migrators.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import logging
 
+import jsonschema
+
 from .types import RTDConfig
+from .validation import validate_config
 
 logger = logging.getLogger(__name__)
 
@@ -42,5 +45,13 @@ async def use_build_tools(config: RTDConfig) -> tuple[RTDConfig, bool]:
     # If python has no keys left, drop it altogether
     if "python" in new_config and not new_config["python"]:
         new_config.pop("python")
+
+    # Validate configuration before returning
+    try:
+        await validate_config(new_config)
+    except jsonschema.exceptions.ValidationError:
+        raise MigrationError(
+            "Produced configuration is invalid, this is an internal problem"
+        )
 
     return new_config, True

--- a/src/readthedocs_assistant/migrators.py
+++ b/src/readthedocs_assistant/migrators.py
@@ -19,7 +19,7 @@ async def use_build_tools(config: RTDConfig) -> tuple[RTDConfig, bool]:
     if config.get("version", 1) < 2:
         raise MigrationError("Config uses V1, migrate to V2 first")
 
-    if config.get("build", {}).get("tools"):
+    if "tools" in config.get("build", {}):
         logger.info("Config already contains build.tools, nothing to do")
         return config, False
 

--- a/src/readthedocs_assistant/migrators.py
+++ b/src/readthedocs_assistant/migrators.py
@@ -9,9 +9,7 @@ class MigrationError(RuntimeError):
     pass
 
 
-async def use_build_tools(
-    config: RTDConfig, *, default_python_version: str = "3.7"
-) -> RTDConfig:
+async def use_build_tools(config: RTDConfig) -> RTDConfig:
     """Migrate to build.tools configuration
 
     See https://docs.readthedocs.io/en/latest/config-file/v2.html#build.
@@ -25,11 +23,10 @@ async def use_build_tools(
         return config
 
     new_config = config.copy()
-    # FIXME: Python version depends on build.image
-    # For example:
-    # 2.0 -> 3.5
-    # 3.0... -> 3.7
-    python_version = config.get("python", {}).get("version", default_python_version)
+
+    # Very old docker images used Python 3.5, but they are not in use anymore
+    # From 4.0 onwards, the default Python version was 3.7
+    python_version = config.get("python", {}).get("version", "3.7")
 
     new_config["build"] = V2Build(
         {

--- a/src/readthedocs_assistant/migrators.py
+++ b/src/readthedocs_assistant/migrators.py
@@ -1,0 +1,45 @@
+import logging
+
+from .types import RTDConfig, V2Build
+
+logger = logging.getLogger(__name__)
+
+
+class MigrationError(RuntimeError):
+    pass
+
+
+async def use_build_tools(
+    config: RTDConfig, default_python_version: str = "3.7"
+) -> RTDConfig:
+    """Migrate to build.tools configuration
+
+    See https://docs.readthedocs.io/en/latest/config-file/v2.html#build.
+    """
+    if config.get("version", 1) < 2:
+        raise MigrationError("Config uses V1, migrate to V2 first")
+
+    if config.get("build", {}).get("tools"):
+        logger.info("Config already contains build.tools, nothing to do")
+        return config
+
+    new_config = config.copy()
+    python_version = config.get("python", {}).get("version", default_python_version)
+
+    new_config["build"] = V2Build(
+        {
+            "os": "ubuntu-20.04",
+            "tools": {"python": python_version},
+        }
+    )
+    if apt_packages := new_config.get("build", {}).get("apt_packages", []):
+        new_config["build"]["apt_packages"] = apt_packages
+
+    # Drop python.version if it exists
+    new_config.get("python", {}).pop("version", None)
+
+    # If python has no keys left, drop it altogether
+    if "python" in new_config and not new_config["python"]:
+        new_config.pop("python")
+
+    return new_config

--- a/src/readthedocs_assistant/migrators.py
+++ b/src/readthedocs_assistant/migrators.py
@@ -10,7 +10,7 @@ class MigrationError(RuntimeError):
 
 
 async def use_build_tools(
-    config: RTDConfig, default_python_version: str = "3.7"
+    config: RTDConfig, *, default_python_version: str = "3.7"
 ) -> RTDConfig:
     """Migrate to build.tools configuration
 

--- a/src/readthedocs_assistant/types.py
+++ b/src/readthedocs_assistant/types.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Literal, TypedDict
+
+Formats = Literal["htmlzip", "pdf", "epub"]
+Tools = Literal["python", "nodejs", "rust", "golang"]
+
+
+class BaseRTDConfig(TypedDict):
+    version: int
+
+
+class LegacyV2Build(TypedDict, total=False):
+    image: Literal["stable", "latest", "testing"]
+    apt_packages: list[str]
+
+
+class BaseV2Build(TypedDict):
+    os: Literal["ubuntu-20.04"]
+    tools: dict[Tools, str]
+
+
+class V2Build(BaseV2Build, total=False):
+    apt_packages: list[str]
+
+
+class PythonRequirements(TypedDict):
+    requirements: str
+
+
+class PythonInstallPath(TypedDict):
+    path: str
+    method: Literal["pip", "setuptools"]
+    extra_requirements: list[str]
+
+
+class Python(TypedDict):
+    version: str
+    system_packages: bool
+    install: list[PythonRequirements | PythonInstallPath]
+
+
+class RTDConfig(BaseRTDConfig, total=False):
+    formats: list[Formats]
+    build: V2Build | LegacyV2Build
+    python: Python

--- a/src/readthedocs_assistant/types.py
+++ b/src/readthedocs_assistant/types.py
@@ -6,17 +6,15 @@ Formats = Literal["htmlzip", "pdf", "epub"]
 Tools = Literal["python", "nodejs", "rust", "golang"]
 
 
-class LegacyV2Build(TypedDict, total=False):
-    image: Literal["stable", "latest", "testing"]
-    apt_packages: list[str]
-
-
-class BaseV2Build(TypedDict):
+# This class mixes several possible specifications
+# depending on the configuration version,
+# but it turns out that crafting a proper specification
+# using Python TypedDict is not possible and also fraught with bugs
+# See https://github.com/python/mypy/issues/11988
+class Build(TypedDict, total=False):
     os: Literal["ubuntu-20.04"]
     tools: dict[Tools, str]
-
-
-class V2Build(BaseV2Build, total=False):
+    image: Literal["stable", "latest", "testing"]
     apt_packages: list[str]
 
 
@@ -39,5 +37,5 @@ class Python(TypedDict, total=False):
 class RTDConfig(TypedDict, total=False):
     version: int
     formats: list[Formats]
-    build: V2Build | LegacyV2Build  # FIXME: What about V1 build?
+    build: Build
     python: Python

--- a/src/readthedocs_assistant/types.py
+++ b/src/readthedocs_assistant/types.py
@@ -6,10 +6,6 @@ Formats = Literal["htmlzip", "pdf", "epub"]
 Tools = Literal["python", "nodejs", "rust", "golang"]
 
 
-class BaseRTDConfig(TypedDict):
-    version: int
-
-
 class LegacyV2Build(TypedDict, total=False):
     image: Literal["stable", "latest", "testing"]
     apt_packages: list[str]
@@ -34,13 +30,14 @@ class PythonInstallPath(TypedDict):
     extra_requirements: list[str]
 
 
-class Python(TypedDict):
+class Python(TypedDict, total=False):
     version: str
     system_packages: bool
     install: list[PythonRequirements | PythonInstallPath]
 
 
-class RTDConfig(BaseRTDConfig, total=False):
+class RTDConfig(TypedDict, total=False):
+    version: int
     formats: list[Formats]
-    build: V2Build | LegacyV2Build
+    build: V2Build | LegacyV2Build  # FIXME: What about V1 build?
     python: Python

--- a/src/readthedocs_assistant/validation.py
+++ b/src/readthedocs_assistant/validation.py
@@ -1,0 +1,28 @@
+import logging
+from typing import Any, cast
+
+import httpx
+from jsonschema import validate
+
+from .types import RTDConfig
+
+logger = logging.getLogger(__name__)
+
+# https://www.schemastore.org/json/
+SCHEMA_URL = (
+    "https://raw.githubusercontent.com/readthedocs/readthedocs.org/"
+    "master/readthedocs/rtd_tests/fixtures/spec/v2/schema.json"
+)
+
+
+async def validate_config(
+    config: Any, schema_url: str = SCHEMA_URL, *, client: httpx.AsyncClient
+) -> RTDConfig:
+    resp_schema = await client.get(SCHEMA_URL)
+    resp_schema.raise_for_status()
+    schema = resp_schema.json()
+    logger.debug(schema)
+
+    validate(instance=config, schema=schema)
+
+    return cast(RTDConfig, config)

--- a/src/readthedocs_assistant/validation.py
+++ b/src/readthedocs_assistant/validation.py
@@ -19,16 +19,11 @@ SCHEMA_URL = (
 Schema = Dict[str, Any]
 
 
-async def _get_schema(
-    schema_url: str = SCHEMA_URL, client: httpx.AsyncClient | None = None
-) -> Schema:
-
-    if not client:
-        client = httpx.AsyncClient()
-
-    resp_schema = await client.get(SCHEMA_URL)
-    resp_schema.raise_for_status()
-    schema = resp_schema.json()
+async def _get_schema(schema_url: str = SCHEMA_URL) -> Schema:
+    async with httpx.AsyncClient() as client:
+        resp_schema = await client.get(SCHEMA_URL)
+        resp_schema.raise_for_status()
+        schema = resp_schema.json()
 
     return cast(Schema, schema)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,7 @@ from readthedocs_assistant.cli import fork_repo
 @mock.patch("readthedocs_assistant.cli.gidgethub.httpx.GitHubAPI", spec=GitHubAPI)
 @pytest.mark.asyncio
 async def test_fork_repo_awaits_fork_repo(mock_gh):
-    await fork_repo("owner", "repo", gh=mock_gh)
+    target_repo = {"full_name": "owner/repo", "name": "repo"}
+    await fork_repo(target_repo, gh=mock_gh)
 
     mock_gh.post.assert_awaited_once_with("/repos/owner/repo/forks", data={})

--- a/tests/test_migrators.py
+++ b/tests/test_migrators.py
@@ -1,0 +1,39 @@
+import pytest
+
+from readthedocs_assistant.migrators import use_build_tools
+
+
+@pytest.mark.parametrize(
+    "config, expected_config",
+    [
+        [
+            {
+                "version": 2,
+            },
+            {"version": 2, "build": {"os": "ubuntu-20.04", "tools": {"python": "3.7"}}},
+        ],
+        [
+            {"version": 2, "python": {"version": "3.8"}},
+            {"version": 2, "build": {"os": "ubuntu-20.04", "tools": {"python": "3.8"}}},
+        ],
+        [
+            {
+                "version": 2,
+                "python": {
+                    "version": "3.8",
+                    "install": {"requirements": "requirements.txt"},
+                },
+            },
+            {
+                "version": 2,
+                "build": {"os": "ubuntu-20.04", "tools": {"python": "3.8"}},
+                "python": {"install": {"requirements": "requirements.txt"}},
+            },
+        ],
+    ],
+)
+@pytest.mark.asyncio
+async def test_use_build_tools_returns_expected_config(config, expected_config):
+    new_config = await use_build_tools(config)
+
+    assert new_config == expected_config

--- a/tests/test_migrators.py
+++ b/tests/test_migrators.py
@@ -34,6 +34,7 @@ from readthedocs_assistant.migrators import use_build_tools
 )
 @pytest.mark.asyncio
 async def test_use_build_tools_returns_expected_config(config, expected_config):
-    new_config = await use_build_tools(config)
+    new_config, applied = await use_build_tools(config)
 
     assert new_config == expected_config
+    assert applied

--- a/tests/test_migrators.py
+++ b/tests/test_migrators.py
@@ -21,13 +21,13 @@ from readthedocs_assistant.migrators import use_build_tools
                 "version": 2,
                 "python": {
                     "version": "3.8",
-                    "install": {"requirements": "requirements.txt"},
+                    "install": [{"requirements": "requirements.txt"}],
                 },
             },
             {
                 "version": 2,
                 "build": {"os": "ubuntu-20.04", "tools": {"python": "3.8"}},
-                "python": {"install": {"requirements": "requirements.txt"}},
+                "python": {"install": [{"requirements": "requirements.txt"}]},
             },
         ],
     ],


### PR DESCRIPTION
Example output:

```
$ python -m readthedocs_assistant.cli
INFO:__main__:readthedocs-assistant/jupyterlite created
INFO:__main__:Current config: {'version': 2, 'conda': {'environment': 'docs/environment.yml'}, 'sphinx': {'builder': 'html', 'configuration': 'docs/conf.py', 'fail_on_warning': True}}
INFO:__main__:New config: {'version': 2, 'conda': {'environment': 'docs/environment.yml'}, 'sphinx': {'builder': 'html', 'configuration': 'docs/conf.py', 'fail_on_warning': True}, 'build': {'os': 'ubuntu-20.04', 'tools': {'python': '3.7'}}}
```